### PR TITLE
fix(address): support clustered usage

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,10 +33,14 @@ jobs:
 
     # Service containers to run with `container-job`
     services:
-      nats:
+      nats01:
         image: nats
         ports:
           - 4222:4222
+      nats02:
+        image: nats
+        ports:
+          - 4223:4222
 
     steps:
       - name: Set up Go ${{ matrix.go }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,6 @@ linters:
   fast: false
   enable:
     - bodyclose
-    - depguard
     - dogsled
     - dupl
     - errcheck

--- a/options.go
+++ b/options.go
@@ -2,9 +2,12 @@ package nats
 
 import (
 	"context"
+	"strings"
 
 	"github.com/golang-queue/queue"
 	"github.com/golang-queue/queue/core"
+
+	"github.com/nats-io/nats.go"
 )
 
 // Option for queue system
@@ -19,9 +22,11 @@ type options struct {
 }
 
 // WithAddr setup the addr of NATS
-func WithAddr(addr string) Option {
+func WithAddr(addrs ...string) Option {
 	return func(w *options) {
-		w.addr = "nats://" + addr
+		if len(addrs) > 0 {
+			w.addr = strings.Join(addrs, ",")
+		}
 	}
 }
 
@@ -55,7 +60,7 @@ func WithLogger(l queue.Logger) Option {
 
 func newOptions(opts ...Option) options {
 	defaultOpts := options{
-		addr:   "127.0.0.1:4222",
+		addr:   nats.DefaultURL,
 		subj:   "foobar",
 		queue:  "foobar",
 		logger: queue.NewLogger(),


### PR DESCRIPTION
- Add `github.com/nats-io/nats.go` as an import
- Change the `WithAddr` function signature to accept multiple addresses
- Modify the `WithAddr` function to join multiple addresses with commas
- Change the default address value to `nats.DefaultURL`

fix #35 